### PR TITLE
fix connection pool with dynamic proxying of connection objects

### DIFF
--- a/src/main/java/test/connection/PoolingDataSource.java
+++ b/src/main/java/test/connection/PoolingDataSource.java
@@ -6,14 +6,28 @@ import test.connection.readonly.DataSource;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 public class PoolingDataSource implements DataSource {
 
     private final BlockingQueue<Connection> queue;
+    private final Map <Connection, Connection> proxyMap;
 
     public PoolingDataSource(DataSource dataSource, int poolSize) {
+
+        Connection conn, proxy;
+        proxyMap = new ConcurrentHashMap<>(poolSize);
         queue = new ArrayBlockingQueue<>(poolSize);
+
         for (int i = 0; i < poolSize; i++) {
-            queue.offer(dataSource.getConnection());
+            conn = dataSource.getConnection();
+            proxy = makeProxy(conn);
+            queue.offer(proxy);
+            proxyMap.put(conn, proxy);
         }
     }
 
@@ -24,6 +38,42 @@ public class PoolingDataSource implements DataSource {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
+        }
+    }
+
+    private void takeBack (Connection conn) {
+        queue.offer(proxyMap.get(conn));
+    }
+
+    private Connection makeProxy (Connection connection) {
+
+        Connection proxy = (Connection) Proxy.
+                newProxyInstance(
+                        connection.getClass().getClassLoader(),
+                        connection.getClass().getInterfaces(),
+                        new ProxyInvoker(connection)
+        );
+        return proxy;
+    }
+
+    private final class ProxyInvoker implements InvocationHandler {
+        private Connection conn = null;
+
+        public ProxyInvoker (Connection connection) {
+            this.conn = connection;
+        }
+
+        @Override
+        public Object invoke(Object proxy,
+                             Method method,
+                             Object[] args) throws Throwable {
+
+            if(method.getName().equals("close")) {
+                takeBack (conn);
+                return null;
+            }
+            else
+                return method.invoke(conn, args) ;
         }
     }
 }


### PR DESCRIPTION
To implement returning connection objects to the pool back, an interception of the close() method of the object has been added.
Additionally, a storage of used objects was created.